### PR TITLE
versioned wire format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.1.2] - 2026-08-26
+
+### Added
+
+- Versioned JSON wire format for expression node serialization: schema 1 documents use a `$schema` and `node` envelope (`ExpressionSerializationWireFormat`); legacy bare-node payloads (schema 0) remain readable.
+
+### Changed
+
+- `ExpressionNodeSerializer` now writes schema 1 envelopes on serialize and accepts both enveloped and legacy documents on deserialize.
+
 ## [10.1.1] - 2026-05-12
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,13 +5,13 @@
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="Mapster" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Mapster" Version="10.0.12" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="NUnit" Version="4.6.0" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Yuck/Komair.git</RepositoryUrl>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.1.1</Version>
+    <Version>10.1.2</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="readme.md" Pack="true" PackagePath="\" />

--- a/src/Komair.Expressions.Mapping.Mapster/readme.md
+++ b/src/Komair.Expressions.Mapping.Mapster/readme.md
@@ -10,8 +10,8 @@ A Mapster-based implementation of the Komair expression mapping abstractions.
 ## Dependencies
 
 - [Mapster](https://www.nuget.org/packages/Mapster)
-- `Komair.Expressions`
-- `Komair.Expressions.Mapping`
+- [Komair.Expressions](https://www.nuget.org/packages/Komair.Expressions)
+- [Komair.Expressions.Mapping](https://www.nuget.org/packages/Komair.Expressions.Mapping)
 
 ## Installation
 

--- a/src/Komair.Expressions.Mapping/readme.md
+++ b/src/Komair.Expressions.Mapping/readme.md
@@ -1,21 +1,19 @@
 # Komair.Expressions.Mapping
 
-A .NET abstraction library for mapping `Komair.Expressions.ExpressionNode` objects to and from other representations (in particular `System.Linq.Expressions`).
+A .NET abstraction library for mapping `Komair.Expressions.ExpressionNode` objects to and from other representations (in particular `System.Linq.Expressions`). Concrete mappers (such as Mapster) live in separate packages and implement `IExpressionNodeMapper`.
 
 ## Key Types
 
-Custom exceptions are in the `Komair.Expressions.Mapping.Exceptions` namespace. Root arguments are validated; passing null for an invalid root throws `ArgumentNullException`.
+- **`IExpressionNodeMapper<T>`** (`Komair.Expressions.Mapping.Abstract.Interfaces`) &ndash; maps between `ExpressionNodeBase` graphs and `System.Linq.Expressions.Expression` trees
+- **`InvalidMemberNodeException`** (`Komair.Expressions.Mapping.Exceptions`) &ndash; thrown when a member expression node lacks the inner expression needed to resolve the member
+- **`InvalidNodeRootException`** (`Komair.Expressions.Mapping.Exceptions`) &ndash; thrown when a mapper expects a `LambdaExpressionNode` at the root but receives another `ExpressionNodeBase` type
+- **`InvalidTreeRootException`** (`Komair.Expressions.Mapping.Exceptions`) &ndash; thrown when a mapper expects a `LambdaExpression` at the root but receives another `System.Linq.Expressions.Expression` shape
 
-- **`InvalidMemberNodeException`** &ndash; thrown when a member expression node lacks the inner expression needed to resolve the member
-- **`InvalidNodeRootException`** &ndash; thrown when a mapper expects a `LambdaExpressionNode` at the root but receives another `ExpressionNodeBase` type
-- **`InvalidTreeRootException`** &ndash; thrown when a mapper expects a `LambdaExpression` at the root but receives another `System.Linq.Expressions.Expression` shape
+Root arguments are validated; passing null for an invalid root throws `ArgumentNullException`.
 
-## Key Concepts
+## Dependencies
 
-- **mapping abstraction** &ndash; defines contracts for converting between serializable expression nodes and runtime expression trees
-- **expression-node centric design** &ndash; focuses on `ExpressionNodeBase` and its derived node types as the mapping boundary
-
-This package does not depend on any specific mapping framework; concrete implementations live in separate packages such as `Komair.Expressions.Mapping.Mapster`.
+- [Komair.Expressions](https://www.nuget.org/packages/Komair.Expressions)
 
 ## Installation
 

--- a/src/Komair.Expressions.Serialization.Json/ExpressionNodeSerializer.cs
+++ b/src/Komair.Expressions.Serialization.Json/ExpressionNodeSerializer.cs
@@ -85,11 +85,27 @@ public class ExpressionNodeSerializer<TExpressionNode>(JsonSerializerOptions? op
         if (schemaVersion > ExpressionSerializationWireFormat.CurrentSchemaVersion)
             throw new ExpressionSerializationException($"Unsupported expression serialization schema version {schemaVersion}; maximum supported version is {ExpressionSerializationWireFormat.CurrentSchemaVersion}.");
 
-        if (schemaVersion < ExpressionSerializationWireFormat.CurrentSchemaVersion)
-            throw new ExpressionSerializationException($"Unsupported expression serialization schema version {schemaVersion}; migrate stored payloads or use a serializer that supports that schema.");
+        return schemaVersion switch
+        {
+            0 => GetSchemaZeroNode(document),
+            1 => GetEnvelopeNode(document),
+            _ => throw new ExpressionSerializationException($"Unsupported expression serialization schema version {schemaVersion}; migrate stored payloads or use a serializer that supports that schema.")
+        };
+    }
 
+    private static JsonObject GetEnvelopeNode(JsonObject document)
+    {
         if (document[ExpressionSerializationWireFormat.NodePropertyName] is not JsonObject nodeDocument)
             throw new ExpressionSerializationException($"Property '{ExpressionSerializationWireFormat.NodePropertyName}' must be a JSON object.");
+
+        return nodeDocument;
+    }
+
+    private static JsonObject GetSchemaZeroNode(JsonObject document)
+    {
+        var nodeDocument = document.DeepClone().AsObject();
+
+        nodeDocument.Remove(ExpressionSerializationWireFormat.SchemaPropertyName);
 
         return nodeDocument;
     }

--- a/src/Komair.Expressions.Serialization.Json/ExpressionNodeSerializer.cs
+++ b/src/Komair.Expressions.Serialization.Json/ExpressionNodeSerializer.cs
@@ -3,6 +3,7 @@ using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
 using Komair.Expressions.Abstract;
+using Komair.Expressions.Serialization;
 using Komair.Expressions.Serialization.Abstract.Interfaces;
 using Komair.Expressions.Serialization.Exceptions;
 using Komair.Expressions.Serialization.Json.Internal;
@@ -21,9 +22,37 @@ public class ExpressionNodeSerializer<TExpressionNode>(JsonSerializerOptions? op
     /// <inheritdoc />
     public TExpressionNode Deserialize(JsonObject document)
     {
-        var json = document.ToJsonString();
+        var nodeDocument = UnwrapNodeDocument(document);
 
-        var result = JsonSerializer.Deserialize<TExpressionNode>(json, _options);
+        return DeserializeNode(nodeDocument);
+    }
+
+    /// <inheritdoc />
+    public JsonObject Serialize(TExpressionNode node)
+    {
+        var nodeDocument = SerializeNode(node);
+
+        return new JsonObject
+        {
+            [ExpressionSerializationWireFormat.SchemaPropertyName] = ExpressionSerializationWireFormat.CurrentSchemaVersion,
+            [ExpressionSerializationWireFormat.NodePropertyName] = nodeDocument
+        };
+    }
+
+    private TExpressionNode DeserializeNode(JsonObject nodeDocument)
+    {
+        var json = nodeDocument.ToJsonString();
+
+        TExpressionNode? result;
+        try
+        {
+            result = JsonSerializer.Deserialize<TExpressionNode>(json, _options);
+        }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException)
+        {
+            throw new ExpressionSerializationException($"Failed to deserialize {typeof(TExpressionNode).Name} from JSON.", exception);
+        }
+
         if (result is ExpressionNodeBase root)
             result = (TExpressionNode) MaterializeConstantValues(root);
 
@@ -33,14 +62,36 @@ public class ExpressionNodeSerializer<TExpressionNode>(JsonSerializerOptions? op
         return result;
     }
 
-    /// <inheritdoc />
-    public JsonObject Serialize(TExpressionNode node)
+    private JsonObject SerializeNode(TExpressionNode node)
     {
         var json = JsonSerializer.SerializeToNode(node, _options);
         if (json is JsonObject value)
             return value;
 
         throw new ExpressionSerializationException("Expected JSON root to be an object.");
+    }
+
+    private static JsonObject UnwrapNodeDocument(JsonObject document)
+    {
+        if (! document.ContainsKey(ExpressionSerializationWireFormat.SchemaPropertyName))
+            return document;
+
+        if (document[ExpressionSerializationWireFormat.SchemaPropertyName] is not JsonValue schemaValue)
+            throw new ExpressionSerializationException($"Property '{ExpressionSerializationWireFormat.SchemaPropertyName}' must be a JSON number.");
+
+        if (! schemaValue.TryGetValue(out Int32 schemaVersion))
+            throw new ExpressionSerializationException($"Property '{ExpressionSerializationWireFormat.SchemaPropertyName}' must be a JSON number.");
+
+        if (schemaVersion > ExpressionSerializationWireFormat.CurrentSchemaVersion)
+            throw new ExpressionSerializationException($"Unsupported expression serialization schema version {schemaVersion}; maximum supported version is {ExpressionSerializationWireFormat.CurrentSchemaVersion}.");
+
+        if (schemaVersion < ExpressionSerializationWireFormat.CurrentSchemaVersion)
+            throw new ExpressionSerializationException($"Unsupported expression serialization schema version {schemaVersion}; migrate stored payloads or use a serializer that supports that schema.");
+
+        if (document[ExpressionSerializationWireFormat.NodePropertyName] is not JsonObject nodeDocument)
+            throw new ExpressionSerializationException($"Property '{ExpressionSerializationWireFormat.NodePropertyName}' must be a JSON object.");
+
+        return nodeDocument;
     }
 
     private static ExpressionNodeBase MaterializeConstantValues(ExpressionNodeBase node)

--- a/src/Komair.Expressions.Serialization.Json/readme.md
+++ b/src/Komair.Expressions.Serialization.Json/readme.md
@@ -6,10 +6,32 @@ A JSON-based implementation of Komair expression serialization using `System.Tex
 
 - **`ExpressionNodeSerializer<TNode>`** &ndash; serializes and deserializes expression node graphs to and from `JsonObject` using `System.Text.Json` polymorphic metadata
 
+## Wire format
+
+Current documents use **schema 1** (see `ExpressionSerializationWireFormat` in `Komair.Expressions.Serialization`):
+
+```json
+{
+  "$schema": 1,
+  "node": { "$type": "Lambda", "nodeType": 18, "type": "...", "body": { ... }, "parameters": [ ] }
+}
+```
+
+**Schema 0 (legacy):** the root object is the node graph (no `$schema` / `node` wrapper). `ExpressionNodeSerializer` still deserializes these payloads.
+
+### Migration notes
+
+| Schema | Layout | Read | Write |
+|--------|--------|------|-------|
+| 0 | Bare node at root | Supported | Not emitted (upgrade by round-tripping through `Serialize`) |
+| 1 | `$schema` + `node` | Supported | Current default |
+
+When node shapes or discriminators change incompatibly, bump `ExpressionSerializationWireFormat.CurrentSchemaVersion`, add a deserialize branch for older schemas, and extend this table.
+
 ## Dependencies
 
-- `Komair.Expressions`
-- `Komair.Expressions.Serialization`
+- [Komair.Expressions](https://www.nuget.org/packages/Komair.Expressions)
+- [Komair.Expressions.Serialization](https://www.nuget.org/packages/Komair.Expressions.Serialization)
 
 ## Installation
 

--- a/src/Komair.Expressions.Serialization/Abstract/Interfaces/IExpressionNodeSerializer.cs
+++ b/src/Komair.Expressions.Serialization/Abstract/Interfaces/IExpressionNodeSerializer.cs
@@ -20,6 +20,6 @@ public interface IExpressionNodeSerializer<T, TExpressionNode> where TExpression
     /// Serializes an expression node graph to a document.
     /// </summary>
     /// <param name="node">The root expression node.</param>
-    /// <returns>The serialized document.</returns>
+    /// <returns>The serialized document. JSON implementations use the versioned envelope described by <see cref="ExpressionSerializationWireFormat"/>.</returns>
     T Serialize(TExpressionNode node);
 }

--- a/src/Komair.Expressions.Serialization/ExpressionSerializationWireFormat.cs
+++ b/src/Komair.Expressions.Serialization/ExpressionSerializationWireFormat.cs
@@ -1,0 +1,27 @@
+namespace Komair.Expressions.Serialization;
+
+/// <summary>
+/// Identifies the versioned JSON envelope produced by <c>Komair.Expressions.Serialization.Json</c>.
+/// </summary>
+/// <remarks>
+/// <para><b>Schema 0 (legacy):</b> the document root is the expression node graph (for example a root <c>$type</c> of <c>Lambda</c>).</para>
+/// <para><b>Schema 1 (current):</b> the document root is an object with <see cref="NodePropertyName"/> holding the node graph and <see cref="SchemaPropertyName"/> set to <see cref="CurrentSchemaVersion"/>.</para>
+/// <para>When node shapes change in a breaking way, increment <see cref="CurrentSchemaVersion"/>, teach <c>ExpressionNodeSerializer</c> to read older schemas, and document migration steps in the JSON package readme.</para>
+/// </remarks>
+public static class ExpressionSerializationWireFormat
+{
+    /// <summary>
+    /// The wire-format schema version written by current serializers.
+    /// </summary>
+    public const Int32 CurrentSchemaVersion = 1;
+
+    /// <summary>
+    /// JSON property that holds the expression node graph in schema 1 documents.
+    /// </summary>
+    public const String NodePropertyName = "node";
+
+    /// <summary>
+    /// JSON property that holds the wire-format schema version in schema 1 documents.
+    /// </summary>
+    public const String SchemaPropertyName = "$schema";
+}

--- a/src/Komair.Expressions.Serialization/readme.md
+++ b/src/Komair.Expressions.Serialization/readme.md
@@ -1,17 +1,18 @@
 # Komair.Expressions.Serialization
 
-An abstraction library for serializing `Komair.Expressions.ExpressionNode` objects to and from other representations (including `System.Linq.Expressions`).
+An abstraction library for serializing `Komair.Expressions.ExpressionNode` objects to and from other representations (including `System.Linq.Expressions`). Concrete serializers (such as JSON) live in separate packages and implement `IExpressionNodeSerializer`.
 
 ## Key Types
 
+- **`ExpressionSerializationWireFormat`** &ndash; documents the versioned JSON envelope (`$schema`, `node`) and the legacy bare-node layout (schema 0)
 - **`ExpressionSerializationException`** (`Komair.Expressions.Serialization.Exceptions`) &ndash; thrown when an `IExpressionNodeSerializer` implementation cannot produce or consume the expected serialized shape (for example a null deserialize result or an unexpected JSON root)
+- **`IExpressionNodeSerializer<T, TExpressionNode>`** (`Komair.Expressions.Serialization.Abstract.Interfaces`) &ndash; serializes and deserializes `ExpressionNodeBase` graphs to a transport document type
 
-## Key Concepts
+Pair this package with `Komair.Expressions.Serialization.Json` in applications that need to send or persist expression trees.
 
-- **serialization boundary** &ndash; defines how `ExpressionNodeBase` graphs are converted to transport-friendly types
-- **pluggable formats** &ndash; concrete serializers (such as JSON) live in separate packages and implement the abstraction interfaces
+## Dependencies
 
-Typical usage is to pair this package with `Komair.Expressions.Serialization.Json` in applications that need to send or persist expression trees.
+- [Komair.Expressions](https://www.nuget.org/packages/Komair.Expressions)
 
 ## Installation
 

--- a/src/Komair.Specifications.EntityFrameworkCore/readme.md
+++ b/src/Komair.Specifications.EntityFrameworkCore/readme.md
@@ -4,12 +4,9 @@ Entity Framework Core query composition helpers for Komair specifications. This 
 
 ## Key Types
 
-- **`QueryableSpecificationExtensions`** &ndash; static extension methods on `IQueryable<T>` that compose Komair specifications with LINQ for use with EF Core. See **Key Methods** for the public surface.
-
-## Key Methods
-
-- **`Where`** &ndash; applies an `ISpecification<T>` as a filter when it always applies.
-- **`WhereIf`** &ndash; overloads that apply a specification or a predicate only when a Boolean condition is true, so optional filters (search fields, toggles) stay in one fluent chain without branching into separate `Where` calls. Prefer `Where` or `Queryable.Where` when the filter is unconditional. Arguments are still evaluated and null-checked before the method runs; see the XML documentation remarks on each overload for details.
+- **`QueryableSpecificationExtensions`** &ndash; static extension methods on `IQueryable<T>` that compose Komair specifications with LINQ for use with EF Core
+- **`Where`** &ndash; applies an `ISpecification<T>` as a filter when it always applies
+- **`WhereIf`** &ndash; overloads that apply a specification or a predicate only when a Boolean condition is true, so optional filters (search fields, toggles) stay in one fluent chain without branching into separate `Where` calls; prefer `Where` or `Queryable.Where` when the filter is unconditional
 
 ## `Where` helper vs `specification.ToExpression()`
 
@@ -34,6 +31,6 @@ Specifications that work for in-memory `IsSatisfiedBy` can still fail translatio
 
 ## Installation
 
-```bash
+```shell
 dotnet add package Komair.Specifications.EntityFrameworkCore
 ```

--- a/src/Komair.Specifications.Validation.Abstractions/readme.md
+++ b/src/Komair.Specifications.Validation.Abstractions/readme.md
@@ -4,13 +4,13 @@ Core abstractions for bridging specification-based rules into validation-oriente
 
 ## Key Types
 
-- `Rules.Abstract.Interfaces.IValidationRuleProvider<T>`: Provides normalized validation rule descriptors for a target model type.
-- `Translations.Abstract.Interfaces.IValidationBridge<T, TArtifact>`: Translates normalized rules into framework-specific artifacts.
-- `Rules.Abstract.Interfaces.IValidationAwareSpecification<T>`: Optional contract for specifications that can expose validation metadata.
-- `Rules.ValidationRuleDescriptor<T>`: Canonical rule shape that combines predicate semantics and validation metadata.
-- `Translations.ValidationTranslationResult<TArtifact>`: Structured translation output with artifacts, warnings, and failures.
-- `Translations.ValidationTranslationFailure`: Structured translation failure details.
-- `Translations.ValidationTranslationWarning`: Structured translation warning details.
+- **`IValidationRuleProvider<T>`** (`Rules.Abstract.Interfaces`) &ndash; provides normalized validation rule descriptors for a target model type
+- **`IValidationBridge<T, TArtifact>`** (`Translations.Abstract.Interfaces`) &ndash; translates normalized rules into framework-specific artifacts
+- **`IValidationAwareSpecification<T>`** (`Rules.Abstract.Interfaces`) &ndash; optional contract for specifications that can expose validation metadata
+- **`ValidationRuleDescriptor<T>`** (`Rules`) &ndash; canonical rule shape that combines predicate semantics and validation metadata
+- **`ValidationTranslationResult<TArtifact>`** (`Translations`) &ndash; structured translation output with artifacts, warnings, and failures
+- **`ValidationTranslationFailure`** (`Translations`) &ndash; structured translation failure details
+- **`ValidationTranslationWarning`** (`Translations`) &ndash; structured translation warning details
 
 ## Usage
 
@@ -23,12 +23,8 @@ var rules = new[]
 };
 ```
 
-## Dependencies
-
-- None
-
 ## Installation
 
-```bash
+```shell
 dotnet add package Komair.Specifications.Validation.Abstractions
 ```

--- a/src/Komair.Specifications.Validation.DataAnnotations/readme.md
+++ b/src/Komair.Specifications.Validation.DataAnnotations/readme.md
@@ -4,20 +4,9 @@ DataAnnotations adapter for Komair specification validation bridge abstractions.
 
 ## Key Types
 
-- `DataAnnotationsBridge<T>`: Translates `ValidationRuleDescriptor<T>` rules into DataAnnotations translation artifacts.
-- `DataAnnotationsRuleArtifact<T>`: Represents either a generated validation attribute artifact or a metadata-only fallback artifact.
-- `DataAnnotationsBridgeExtensions`: Convenience extensions for building DataAnnotations translation results from descriptors or `ISpecification<T>` instances.
-
-## Dependencies
-
-- [Komair.Specifications](https://www.nuget.org/packages/Komair.Specifications/)
-- [Komair.Specifications.Validation.Abstractions](https://www.nuget.org/packages/Komair.Specifications.Validation.Abstractions/)
-
-## Installation
-
-```bash
-dotnet add package Komair.Specifications.Validation.DataAnnotations
-```
+- **`DataAnnotationsBridge<T>`** &ndash; translates `ValidationRuleDescriptor<T>` rules into DataAnnotations translation artifacts
+- **`DataAnnotationsRuleArtifact<T>`** &ndash; represents either a generated validation attribute artifact or a metadata-only fallback artifact
+- **`DataAnnotationsBridgeExtensions`** &ndash; convenience extensions for building DataAnnotations translation results from descriptors or `ISpecification<T>` instances
 
 ## Usage
 
@@ -47,4 +36,15 @@ public sealed class AdultUserSpecification : SpecificationBase<User>
 
 var specification = new AdultUserSpecification();
 var translationFromSpecification = specification.ToDataAnnotationsArtifacts("User must be an adult", errorCode: "AGE001");
+```
+
+## Dependencies
+
+- [Komair.Specifications](https://www.nuget.org/packages/Komair.Specifications/)
+- [Komair.Specifications.Validation.Abstractions](https://www.nuget.org/packages/Komair.Specifications.Validation.Abstractions/)
+
+## Installation
+
+```shell
+dotnet add package Komair.Specifications.Validation.DataAnnotations
 ```

--- a/src/Komair.Specifications.Validation.FluentValidation/readme.md
+++ b/src/Komair.Specifications.Validation.FluentValidation/readme.md
@@ -4,20 +4,8 @@ FluentValidation adapter for Komair specification validation bridge abstractions
 
 ## Key Types
 
-- `FluentValidationBridge<T>`: Translates `ValidationRuleDescriptor<T>` rules into a FluentValidation `IValidator<T>` artifact.
-- `FluentValidationBridgeExtensions`: Convenience extensions for building validators from descriptors or `ISpecification<T>` instances.
-
-## Dependencies
-
-- [FluentValidation](https://www.nuget.org/packages/FluentValidation/)
-- [Komair.Specifications](https://www.nuget.org/packages/Komair.Specifications/)
-- [Komair.Specifications.Validation.Abstractions](https://www.nuget.org/packages/Komair.Specifications.Validation.Abstractions/)
-
-## Installation
-
-```bash
-dotnet add package Komair.Specifications.Validation.FluentValidation
-```
+- **`FluentValidationBridge<T>`** &ndash; translates `ValidationRuleDescriptor<T>` rules into a FluentValidation `IValidator<T>` artifact
+- **`FluentValidationBridgeExtensions`** &ndash; convenience extensions for building validators from descriptors or `ISpecification<T>` instances
 
 ## Usage
 
@@ -47,4 +35,16 @@ public sealed class AdultUserSpecification : SpecificationBase<User>
 
 var specification = new AdultUserSpecification();
 var validatorFromSpecification = specification.ToFluentValidator("User must be an adult", errorCode: "AGE001");
+```
+
+## Dependencies
+
+- [FluentValidation](https://www.nuget.org/packages/FluentValidation/)
+- [Komair.Specifications](https://www.nuget.org/packages/Komair.Specifications/)
+- [Komair.Specifications.Validation.Abstractions](https://www.nuget.org/packages/Komair.Specifications.Validation.Abstractions/)
+
+## Installation
+
+```shell
+dotnet add package Komair.Specifications.Validation.FluentValidation
 ```

--- a/src/Komair.Specifications/readme.md
+++ b/src/Komair.Specifications/readme.md
@@ -2,15 +2,14 @@
 
 A .NET implementation of the Specification pattern for building composable business rules.
 
-## Key Concepts
+## Key Types
 
 - **`ISpecification<T>`** &ndash; abstraction for a predicate that can be combined and evaluated
+- **`SpecificationBase<T>`** &ndash; base class with `And`, `Or`, and `Not` combinators and `ToExpression` for LINQ providers
+- **`TrueSpecification<T>.Identity` / `FalseSpecification<T>.Identity`** &ndash; neutral elements for folding specifications: true for `And`, false for `Or`
 - **`And` / `Or` with `params`** &ndash; fold any number of specifications onto the receiver (e.g. `mySpec.And(a, b)` is equivalent to chaining `mySpec.And(a).And(b)`; same idea for `Or`)
-- **`TrueSpecification<T>.Identity` / `FalseSpecification<T>.Identity`** &ndash; neutral elements for those folds: true for `And`, false for `Or`
-- **combinators** &ndash; `And`, `Or`, and `Not` specifications for composing more complex rules
-- **expression pipeline** &ndash; `ToExpression` and `Where` expose `Expression<Func<T, Boolean>>` for use with LINQ providers
 
-## Starting from `Identity`
+## Usage
 
 Use the always-true identity when you want “and together these specs” without an existing left-hand specification:
 
@@ -25,8 +24,6 @@ var spec = FalseSpecification<Order>.Identity.Or(draft, archived, pendingReview)
 ```
 
 With no extra arguments, `TrueSpecification<T>.Identity.And()` stays always true, and `FalseSpecification<T>.Identity.Or()` stays always false. You can still start from any other specification instead (e.g. `active.And(paid, shipped)`).
-
-## Typical Usage
 
 Use specifications to encapsulate complex predicates, compose them fluently, and reuse them across repositories, query handlers, and validation layers.
 

--- a/test/Komair.Expressions.Serialization.Json.UnitTests/ExpressionNodeSerializerTests.cs
+++ b/test/Komair.Expressions.Serialization.Json.UnitTests/ExpressionNodeSerializerTests.cs
@@ -2,7 +2,9 @@ using System.Linq.Expressions;
 using System.Text.Json.Nodes;
 using Komair.Expressions.Abstract;
 using Komair.Expressions.Mapping.Mapster;
+using Komair.Expressions.Serialization;
 using Komair.Expressions.Serialization.Abstract.Interfaces;
+using Komair.Expressions.Serialization.Exceptions;
 using NUnit.Framework;
 
 namespace Komair.Expressions.Serialization.Json.UnitTests;
@@ -15,12 +17,66 @@ public class ExpressionNodeSerializerTests
     }
 
     [Test]
-    public void Deserialize_WhenJsonEmpty_Throws()
+    public void Deserialize_WhenEnvelopeMissingNode_ThrowsExpressionSerializationException()
+    {
+        var serializer = GetSerializer();
+        var document = new JsonObject
+        {
+            [ExpressionSerializationWireFormat.SchemaPropertyName] = ExpressionSerializationWireFormat.CurrentSchemaVersion
+        };
+
+        var exception = Assert.Throws<ExpressionSerializationException>(() => serializer.Deserialize(document));
+
+        Assert.That(exception!.Message, Does.Contain(ExpressionSerializationWireFormat.NodePropertyName));
+    }
+
+    [Test]
+    public void Deserialize_WhenJsonEmpty_ThrowsExpressionSerializationException()
     {
         var serializer = GetSerializer();
         var empty = new JsonObject();
 
-        Assert.Throws<NotSupportedException>(() => serializer.Deserialize(empty));
+        Assert.Throws<ExpressionSerializationException>(() => serializer.Deserialize(empty));
+    }
+
+    [Test]
+    public void Deserialize_WhenLegacyBareNodeFormat_RoundTrips()
+    {
+        var mapper = new MapsterExpressionNodeMapper<Func<Int32>>();
+        var serializer = GetSerializer();
+
+        var node = mapper.ToExpressionNode(CreateExpression());
+        var envelope = serializer.Serialize(node);
+        var legacy = envelope[ExpressionSerializationWireFormat.NodePropertyName]!.AsObject();
+
+        var deserialized = serializer.Deserialize(legacy);
+        var roundTripped = mapper.ToExpression(deserialized);
+
+        Assert.AreEqual(42, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Int32>> CreateExpression() => () => 42;
+    }
+
+    [Test]
+    public void Deserialize_WhenSchemaVersionUnsupported_ThrowsExpressionSerializationException()
+    {
+        var mapper = new MapsterExpressionNodeMapper<Func<Int32>>();
+        var serializer = GetSerializer();
+
+        var node = mapper.ToExpressionNode(CreateExpression());
+        var envelope = serializer.Serialize(node);
+
+        envelope[ExpressionSerializationWireFormat.SchemaPropertyName] = 99;
+
+        var exception = Assert.Throws<ExpressionSerializationException>(() => serializer.Deserialize(envelope));
+
+        Assert.That(exception!.Message, Does.Contain("99"));
+
+        return;
+
+        Expression<Func<Int32>> CreateExpression() => () => 42;
     }
 
     [Test]
@@ -28,14 +84,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<Boolean>>();
         var serializer = GetSerializer();
-        Expression<Func<Boolean>> expression = () => true;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.IsTrue(roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Boolean>> CreateExpression() => () => true;
     }
 
     [Test]
@@ -43,14 +102,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<Double>>();
         var serializer = GetSerializer();
-        Expression<Func<Double>> expression = () => 3.14;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.AreEqual(3.14, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Double>> CreateExpression() => () => 3.14;
     }
 
     [Test]
@@ -58,14 +120,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<ExpressionType>>();
         var serializer = GetSerializer();
-        Expression<Func<ExpressionType>> expression = () => ExpressionType.Lambda;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.AreEqual(ExpressionType.Lambda, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<ExpressionType>> CreateExpression() => () => ExpressionType.Lambda;
     }
 
     [Test]
@@ -73,14 +138,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<Int32>>();
         var serializer = GetSerializer();
-        Expression<Func<Int32>> expression = () => 42;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.AreEqual(42, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Int32>> CreateExpression() => () => 42;
     }
 
     [Test]
@@ -88,14 +156,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<Int64>>();
         var serializer = GetSerializer();
-        Expression<Func<Int64>> expression = () => 42L;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.AreEqual(42L, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Int64>> CreateExpression() => () => 42L;
     }
 
     [Test]
@@ -105,10 +176,9 @@ public class ExpressionNodeSerializerTests
         var mapper = new MapsterExpressionNodeMapper<Func<String, Boolean>>();
         var serializer = GetSerializer();
 
-        Expression<Func<String, Boolean>> expression1 = t => t.Length > 0;
-        var expected = expression1.Compile()(value);
+        var expected = CreateExpression().Compile()(value);
 
-        var node1 = mapper.ToExpressionNode(expression1);
+        var node1 = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node1);
         var node2 = serializer.Deserialize(serialized);
 
@@ -116,6 +186,10 @@ public class ExpressionNodeSerializerTests
         var actual = expression2.Compile()(value);
 
         Assert.AreEqual(expected, actual);
+
+        return;
+
+        Expression<Func<String, Boolean>> CreateExpression() => t => t.Length > 0;
     }
 
     [Test]
@@ -124,10 +198,10 @@ public class ExpressionNodeSerializerTests
         const String value = "test";
         var mapper = new MapsterExpressionNodeMapper<Func<String, TestModel>>();
         var serializer = GetSerializer();
-        Expression<Func<String, TestModel>> expression1 = t => new TestModel { Value = t.Length };
-        var expected = expression1.Compile()(value).Value;
 
-        var node1 = mapper.ToExpressionNode(expression1);
+        var expected = CreateExpression().Compile()(value).Value;
+
+        var node1 = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node1);
         var node2 = serializer.Deserialize(serialized);
 
@@ -135,6 +209,10 @@ public class ExpressionNodeSerializerTests
         var actual = expression2.Compile()(value).Value;
 
         Assert.AreEqual(expected, actual);
+
+        return;
+
+        Expression<Func<String, TestModel>> CreateExpression() => t => new TestModel { Value = t.Length };
     }
 
     [Test]
@@ -142,14 +220,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<String?>>();
         var serializer = GetSerializer();
-        Expression<Func<String?>> expression = () => null;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.IsNull(roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<String?>> CreateExpression() => () => null;
     }
 
     [Test]
@@ -157,14 +238,17 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<Single>>();
         var serializer = GetSerializer();
-        Expression<Func<Single>> expression = () => 3.14f;
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.AreEqual(3.14f, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Single>> CreateExpression() => () => 3.14f;
     }
 
     [Test]
@@ -172,14 +256,35 @@ public class ExpressionNodeSerializerTests
     {
         var mapper = new MapsterExpressionNodeMapper<Func<String>>();
         var serializer = GetSerializer();
-        Expression<Func<String>> expression = () => "hello";
 
-        var node = mapper.ToExpressionNode(expression);
+        var node = mapper.ToExpressionNode(CreateExpression());
         var serialized = serializer.Serialize(node);
         var deserialized = serializer.Deserialize(serialized);
         var roundTripped = mapper.ToExpression(deserialized);
 
         Assert.AreEqual("hello", roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<String>> CreateExpression() => () => "hello";
+    }
+
+    [Test]
+    public void Serialize_WhenNodeSerialized_IncludesSchemaAndNodeEnvelope()
+    {
+        var mapper = new MapsterExpressionNodeMapper<Func<Int32>>();
+        var serializer = GetSerializer();
+
+        var node = mapper.ToExpressionNode(CreateExpression());
+        var serialized = serializer.Serialize(node);
+
+        Assert.AreEqual(ExpressionSerializationWireFormat.CurrentSchemaVersion, serialized[ExpressionSerializationWireFormat.SchemaPropertyName]!.GetValue<Int32>());
+        Assert.IsInstanceOf<JsonObject>(serialized[ExpressionSerializationWireFormat.NodePropertyName]);
+        Assert.AreEqual("Lambda", serialized[ExpressionSerializationWireFormat.NodePropertyName]!["$type"]!.GetValue<String>());
+
+        return;
+
+        Expression<Func<Int32>> CreateExpression() => () => 42;
     }
 
     public class TestModel

--- a/test/Komair.Expressions.Serialization.Json.UnitTests/ExpressionNodeSerializerTests.cs
+++ b/test/Komair.Expressions.Serialization.Json.UnitTests/ExpressionNodeSerializerTests.cs
@@ -80,6 +80,28 @@ public class ExpressionNodeSerializerTests
     }
 
     [Test]
+    public void Deserialize_WhenSchemaVersionZero_RoundTrips()
+    {
+        var mapper = new MapsterExpressionNodeMapper<Func<Int32>>();
+        var serializer = GetSerializer();
+
+        var node = mapper.ToExpressionNode(CreateExpression());
+        var envelope = serializer.Serialize(node);
+        var schemaZero = envelope[ExpressionSerializationWireFormat.NodePropertyName]!.AsObject().DeepClone().AsObject();
+
+        schemaZero[ExpressionSerializationWireFormat.SchemaPropertyName] = 0;
+
+        var deserialized = serializer.Deserialize(schemaZero);
+        var roundTripped = mapper.ToExpression(deserialized);
+
+        Assert.AreEqual(42, roundTripped.Compile()());
+
+        return;
+
+        Expression<Func<Int32>> CreateExpression() => () => 42;
+    }
+
+    [Test]
     public void Serialize_WhenExpressionRoundTripsWithBooleanConstant_ReturnsTrue()
     {
         var mapper = new MapsterExpressionNodeMapper<Func<Boolean>>();


### PR DESCRIPTION
CLOSES #18

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Serialize output shape changes for all new writes, which can break external consumers that expect a bare node at the JSON root unless they adopt the envelope or only use the serializer API. Deserialize remains backward compatible for legacy payloads.
> 
> **Overview**
> Introduces **schema 1** JSON envelopes for expression node serialization: serialized documents now include **`$schema`** and a **`node`** property (via `ExpressionSerializationWireFormat`), instead of putting the node graph at the document root.
> 
> **`ExpressionNodeSerializer`** wraps on serialize and unwraps on deserialize. **Legacy schema 0** payloads (bare node at root, or `$schema: 0`) still deserialize; unsupported future schema versions fail with `ExpressionSerializationException`. JSON deserialization errors are wrapped in `ExpressionSerializationException` rather than surfacing raw `JsonException` / `NotSupportedException`.
> 
> Ships as **10.1.2** with changelog, central package version bumps, and readme/documentation alignment across Komair packages (wire format migration table in the JSON package readme).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f535d2e989b0e7128bd2f542884660204120f40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->